### PR TITLE
🎨 Make kontaktweg optional in BO Geschaeftsparter

### DIFF
--- a/src/bo4e/bo/geschaeftspartner.py
+++ b/src/bo4e/bo/geschaeftspartner.py
@@ -70,7 +70,7 @@ class Geschaeftspartner(Geschaeftsobjekt):
     #: Amtsgericht bzw Handelsregistergericht, das die Handelsregisternummer herausgegeben hat
     amtsgericht: Optional[str] = None
     #: Bevorzugte Kontaktwege des Geschäftspartners
-    kontaktweg: List[Kontaktart] = []
+    kontaktweg: Optional[List[Kontaktart]] = []
     #: Die Steuer-ID des Geschäftspartners; Beispiel: "DE 813281825"
     umsatzsteuer_id: Optional[str] = None
     #: Die Gläubiger-ID welche im Zahlungsverkehr verwendet wird; Z.B. "DE 47116789"


### PR DESCRIPTION
There was a small error in the pydantic rework, the attribute `kontaktweg` of the BO Geschaeftspartner was not optional like the [BO4E documentation](https://www.bo4e.de/dokumentation/geschaeftsobjekte/bo-geschaftspartner) says.
This PR fixes it
![](https://www.bo4e.de/assets/BO-GeschaeftsPartner.png)
