### PR TITLE
Extend ENUM Sparte: Add `STROM_UND_GAS`

### DIFF
--- a/src/bo4e/enum/sparte.py
+++ b/src/bo4e/enum/sparte.py
@@ -14,3 +14,4 @@ class Sparte(StrEnum):
     NAHWAERME = "NAHWAERME"
     WASSER = "WASSER"
     ABWASSER = "ABWASSER"
+    STROM_UND_GAS = "STROM_UND_GAS"


### PR DESCRIPTION
https://www.bo4e.de/dokumentation/enumerations/enum-leistungstyp/23-2-2022

Ich weiß ehrlich gesagt nicht, warum wir das machen.