### PR TITLE
(chore) Strip docstrings in autogenerated json schemas (Python 3.11)

### DIFF
--- a/json_schemas/bo/Buendelvertrag.json
+++ b/json_schemas/bo/Buendelvertrag.json
@@ -806,6 +806,10 @@
     },
     "description": "Abbildung eines Bündelvertrags.\nEs handelt sich hierbei um eine Liste von Einzelverträgen, die in einem Vertragsobjekt gebündelt sind.\n\n.. raw:: html\n\n    <object data=\"../_static/images/bo4e/bo/Buendelvertrag.svg\" type=\"image/svg+xml\"></object>\n\n.. HINT::\n    `Buendelvertrag JSON Schema <https://json-schema.app/view/%23?url=https://raw.githubusercontent.com/Hochfrequenz/BO4E-python/main/json_schemas/bo/Buendelvertrag.json>`_",
     "properties": {
+        "beschreibung": {
+            "title": "Beschreibung",
+            "type": "string"
+        },
         "boTyp": {
             "allOf": [
                 {
@@ -815,10 +819,10 @@
             "default": "BUENDELVERTRAG"
         },
         "einzelvertraege": {
+            "default": [],
             "items": {
                 "$ref": "#/definitions/Vertrag"
             },
-            "minItems": 1,
             "title": "Einzelvertraege",
             "type": "array"
         },
@@ -830,14 +834,74 @@
             "title": "Externereferenzen",
             "type": "array"
         },
+        "sparte": {
+            "$ref": "#/definitions/Sparte"
+        },
+        "unterzeichnervp1": {
+            "default": [],
+            "items": {
+                "$ref": "#/definitions/Unterschrift"
+            },
+            "title": "Unterzeichnervp1",
+            "type": "array"
+        },
+        "unterzeichnervp2": {
+            "default": [],
+            "items": {
+                "$ref": "#/definitions/Unterschrift"
+            },
+            "title": "Unterzeichnervp2",
+            "type": "array"
+        },
         "versionstruktur": {
             "default": "2",
             "title": "Versionstruktur",
             "type": "string"
+        },
+        "vertragsart": {
+            "$ref": "#/definitions/Vertragsart"
+        },
+        "vertragsbeginn": {
+            "format": "date-time",
+            "title": "Vertragsbeginn",
+            "type": "string"
+        },
+        "vertragsende": {
+            "format": "date-time",
+            "title": "Vertragsende",
+            "type": "string"
+        },
+        "vertragskonditionen": {
+            "default": [],
+            "items": {
+                "$ref": "#/definitions/Vertragskonditionen"
+            },
+            "title": "Vertragskonditionen",
+            "type": "array"
+        },
+        "vertragsnummer": {
+            "title": "Vertragsnummer",
+            "type": "string"
+        },
+        "vertragspartner1": {
+            "$ref": "#/definitions/Geschaeftspartner"
+        },
+        "vertragspartner2": {
+            "$ref": "#/definitions/Geschaeftspartner"
+        },
+        "vertragsstatus": {
+            "$ref": "#/definitions/Vertragsstatus"
         }
     },
     "required": [
-        "einzelvertraege"
+        "vertragsnummer",
+        "vertragsart",
+        "vertragsstatus",
+        "sparte",
+        "vertragsbeginn",
+        "vertragsende",
+        "vertragspartner1",
+        "vertragspartner2"
     ],
     "title": "Buendelvertrag",
     "type": "object"

--- a/json_schemas/bo/Kosten.json
+++ b/json_schemas/bo/Kosten.json
@@ -102,7 +102,7 @@
             "type": "object"
         },
         "Kostenklasse": {
-            "description": "Kostenklassen bilden die oberste Ebene der verschiedenen Kosten.\nIn der Regel werden die Gesamtkosten einer Kostenklasse in einer App berechnet.",
+            "description": "Kostenklassen bilden die oberste Ebene der verschiedenen Kosten.\n    In der Regel werden die Gesamtkosten einer Kostenklasse in einer App berechnet.",
             "enum": [
                 "FREMDKOSTEN",
                 "BESCHAFFUNG",

--- a/json_schemas/bo/Tarifkosten.json
+++ b/json_schemas/bo/Tarifkosten.json
@@ -351,7 +351,7 @@
             "type": "object"
         },
         "Kostenklasse": {
-            "description": "Kostenklassen bilden die oberste Ebene der verschiedenen Kosten.\nIn der Regel werden die Gesamtkosten einer Kostenklasse in einer App berechnet.",
+            "description": "Kostenklassen bilden die oberste Ebene der verschiedenen Kosten.\n    In der Regel werden die Gesamtkosten einer Kostenklasse in einer App berechnet.",
             "enum": [
                 "FREMDKOSTEN",
                 "BESCHAFFUNG",

--- a/json_schemas/generate_json_schemas.py
+++ b/json_schemas/generate_json_schemas.py
@@ -5,6 +5,7 @@ It creates json schema files as described in the README.md in the same directory
 
 import importlib
 import inspect
+import json
 import pathlib
 import pkgutil
 
@@ -21,5 +22,10 @@ for pkg in pkgs:
         for name, cls in cls_list:
             this_directory = pathlib.Path(__file__).parent.absolute()
             file_path = this_directory / pkg / (name + ".json")  # pylint:disable=invalid-name
+            schema_json_dict = json.loads(cls.schema_json(ensure_ascii=False, sort_keys=True, indent=4))
+            if "definitions" in schema_json_dict:
+                for definition in schema_json_dict["definitions"].values():
+                    # this sanitizing step is necessary since python 3.11
+                    definition["description"] = definition["description"].strip()
             with open(file_path, "w+", encoding="utf-8") as json_schema_file:
-                json_schema_file.write(cls.schema_json(ensure_ascii=False, sort_keys=True, indent=4))
+                json_schema_file.write(json.dumps(schema_json_dict, ensure_ascii=False, indent=4))


### PR DESCRIPTION
`tox -e json_schemas`