### PR TITLE
(chore) Remove unnecessary type ignore

### DIFF
--- a/tests/test_externe_referenz.py
+++ b/tests/test_externe_referenz.py
@@ -40,8 +40,8 @@ class TestExterneReferenz:
         gp_json = gp.model_dump_json(by_alias=True)
 
         deserialized_gp: Geschaeftspartner = Geschaeftspartner.model_validate_json(gp_json)
-        assert len(deserialized_gp.externe_referenzen) == 2  # type: ignore[arg-type]
-        assert deserialized_gp.externe_referenzen[0].ex_ref_name == "SAP GP Nummer"  # type: ignore[index]
+        assert len(deserialized_gp.externe_referenzen) == 2
+        assert deserialized_gp.externe_referenzen[0].ex_ref_name == "SAP GP Nummer"
 
     def test_geschaeftspartner_with_no_externe_referenz(self) -> None:
         gp = Geschaeftspartner(


### PR DESCRIPTION
fixes
> tests\test_externe_referenz.py:43: error: Unused "type: ignore" comment  [unused-ignore]
tests\test_externe_referenz.py:44: error: Unused "type: ignore" comment  [unused-ignore]

caused by unpinned dependencies #474 
