### PR TITLE
remove required python version in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,6 @@ BO4E
 Gleichzeitig ist dieses Repository der Ort, um Fragen und Erweiterungen des BO4E-Standards zu diskutieren.
 
 🇬🇧 This is a Python library that implements Business Objects for Energy `BO4E <https://www.bo4e.de/>`_.
-It requires Python >=3.10.
 
 Dokumentation / Fragen und Anregungen zum BO4E Datenmodell
 ==========================================================


### PR DESCRIPTION
The required python version is already part of the setup.cfg
 https://github.com/bo4e/BO4E-python/blob/8772f8f9b6e306d3b44ee7ac34db0f379f625497/setup.cfg#L26