### PR TITLE
657 Erweiterung des Enums `Anrede`

### DIFF
--- a/src/bo4e/enum/anrede.py
+++ b/src/bo4e/enum/anrede.py
@@ -11,4 +11,6 @@ class Anrede(StrEnum):
     FRAU = "FRAU"  #: Frau
     EHELEUTE = "EHELEUTE"  #: Eheleute
     FIRMA = "FIRMA"  #: Firma
-    INDIVIDUELL = "INDIVIDUELL"  #: Individuell (z.B. "Profx")
+    FAMILIE = "FAMILIE"  #: Familie
+    ERBENGEMEINSCHAFT = "ERBENGEMEINSCHAFT"  #: Erbengemeinschaft
+    GRUNDSTUECKSGEMEINSCHAFT = "GRUNDSTUECKSGEMEINSCHAFT"  #: Grundstücksgemeinschaft


### PR DESCRIPTION
https://github.com/bo4e/BO4E-python/issues/657

wie in dem Ticket #657  festgehalten wird in dem PR das ENUM Anrede erweitert um 
```python
    FAMILIE = "FAMILIE"  #: Familie
    ERBENGEMEINSCHAFT = "ERBENGEMEINSCHAFT"  #: Erbengemeinschaft
    GRUNDSTUECKSGEMEINSCHAFT = "GRUNDSTUECKSGEMEINSCHAFT"  #: Grundstücksgemeinschaft
```
Der Wert `INDIVIDUELL` wurde entfernt.