### PR TITLE
💚 Add GH action to merge automatically dependabot PRs

### DIFF
--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -1,0 +1,18 @@
+name: Dependabot auto-approve / -merge
+on: pull_request
+
+jobs:
+  dependabot:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    env:
+      PR_URL: ${{github.event.pull_request.html_url}}
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
This PR adds a GitHub Action which automatically approves the PRs of the Dependabot.
If all checks (unit tests, linter, etc) passed, the PR will automatically get merged.

This keeps the dependecies always up to date and saves a lot of repetitive work
