### PR TITLE
⬆️ Bump os build version for read-the-docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.11"
     # You can also specify other tool versions:


### PR DESCRIPTION
this PR should get merged after #673.
With the PR #673 the documentation will also get fixed.