### PR TITLE
Fix scheduled trigger to actually trigger in January and July

### DIFF
--- a/.github/workflows/python-publish-scheduled.yml
+++ b/.github/workflows/python-publish-scheduled.yml
@@ -6,7 +6,7 @@ name: Upload Python Package Scheduled
 on:
   schedule:
     # At 01:23 on 1st January and every 6 months afterward
-    - cron: '23 1 1 1/6 *'
+    - cron: '23 1 1 1,7 *'
 
 jobs:
   tests:


### PR DESCRIPTION
old:
> Runs at 01:23, on day 1 of the month, every 6 months.
Actions schedules run at most every 5 minutes using UTC time.

new:
> Runs at 01:23, on day 1 of the month, only in January and July.
Actions schedules run at most every 5 minutes using UTC time.

Explanation
https://chat.openai.com/c/50754ff2-7aa6-4477-8537-b46652ba3e11