### PR TITLE
📝 improve documentation regarding Ferraris Zähler

### DIFF
--- a/src/bo4e/enum/zaehlertyp.py
+++ b/src/bo4e/enum/zaehlertyp.py
@@ -8,16 +8,16 @@ class Zaehlertyp(StrEnum):
     Bei diesem Enum handelt es sich um die Abbildung von Zählertypen der Sparten Strom und Gas.
     """
 
-    DREHSTROMZAEHLER = "DREHSTROMZAEHLER"
     #: Drehstromzähler - dieser Zählertyp wird für dreiphasige Ferraris-Zähler verwendet
+    DREHSTROMZAEHLER = "DREHSTROMZAEHLER"
     BALGENGASZAEHLER = "BALGENGASZAEHLER"  #: Balgengaszähler
     DREHKOLBENZAEHLER = "DREHKOLBENZAEHLER"  #: Drehkolbengaszähler
     LEISTUNGSZAEHLER = "LEISTUNGSZAEHLER"  #: leistungsmessender Zähler
     MAXIMUMZAEHLER = "MAXIMUMZAEHLER"  #: Maximumzähler
     TURBINENRADGASZAEHLER = "TURBINENRADGASZAEHLER"  #: Turbinenradgaszähler
     ULTRASCHALLGASZAEHLER = "ULTRASCHALLGASZAEHLER"  #: Ultraschallgaszähler
-    WECHSELSTROMZAEHLER = "WECHSELSTROMZAEHLER"
     #: Wechselstromzähler - dieser Zählertyp wird für einphasige Ferraris-Zähler verwendet
+    WECHSELSTROMZAEHLER = "WECHSELSTROMZAEHLER"
     MODERNE_MESSEINRICHTUNG = "MODERNE_MESSEINRICHTUNG"  #: Moderne Messeinrichtung
     INTELLIGENTES_MESSSYSTEM = "INTELLIGENTES_MESSSYSTEM"  #: Intelligentes Messsystem
     ELEKTRONISCHER_ZAEHLER = "ELEKTRONISCHER_ZAEHLER"  #: Elektronischer Zähler

--- a/src/bo4e/enum/zaehlertyp.py
+++ b/src/bo4e/enum/zaehlertyp.py
@@ -8,14 +8,18 @@ class Zaehlertyp(StrEnum):
     Bei diesem Enum handelt es sich um die Abbildung von Zählertypen der Sparten Strom und Gas.
     """
 
-    DREHSTROMZAEHLER = "DREHSTROMZAEHLER"  #: Drehstromzähler - dieser Zählertyp wird für Ferraris-Zähler verwendet
+    DREHSTROMZAEHLER = (
+        "DREHSTROMZAEHLER"  #: Drehstromzähler - dieser Zählertyp wird für dreiphasige Ferraris-Zähler verwendet
+    )
     BALGENGASZAEHLER = "BALGENGASZAEHLER"  #: Balgengaszähler
     DREHKOLBENZAEHLER = "DREHKOLBENZAEHLER"  #: Drehkolbengaszähler
     LEISTUNGSZAEHLER = "LEISTUNGSZAEHLER"  #: leistungsmessender Zähler
     MAXIMUMZAEHLER = "MAXIMUMZAEHLER"  #: Maximumzähler
     TURBINENRADGASZAEHLER = "TURBINENRADGASZAEHLER"  #: Turbinenradgaszähler
     ULTRASCHALLGASZAEHLER = "ULTRASCHALLGASZAEHLER"  #: Ultraschallgaszähler
-    WECHSELSTROMZAEHLER = "WECHSELSTROMZAEHLER"  #: Wechselstromzähler
+    WECHSELSTROMZAEHLER = (
+        "WECHSELSTROMZAEHLER"  #: Wechselstromzähler - dieser Zählertyp wird für einphasige Ferraris-Zähler verwendet
+    )
     MODERNE_MESSEINRICHTUNG = "MODERNE_MESSEINRICHTUNG"  #: Moderne Messeinrichtung
     INTELLIGENTES_MESSSYSTEM = "INTELLIGENTES_MESSSYSTEM"  #: Intelligentes Messsystem
     ELEKTRONISCHER_ZAEHLER = "ELEKTRONISCHER_ZAEHLER"  #: Elektronischer Zähler

--- a/src/bo4e/enum/zaehlertyp.py
+++ b/src/bo4e/enum/zaehlertyp.py
@@ -8,18 +8,16 @@ class Zaehlertyp(StrEnum):
     Bei diesem Enum handelt es sich um die Abbildung von Zählertypen der Sparten Strom und Gas.
     """
 
-    DREHSTROMZAEHLER = (
-        "DREHSTROMZAEHLER"  #: Drehstromzähler - dieser Zählertyp wird für dreiphasige Ferraris-Zähler verwendet
-    )
+    DREHSTROMZAEHLER = "DREHSTROMZAEHLER"
+    #: Drehstromzähler - dieser Zählertyp wird für dreiphasige Ferraris-Zähler verwendet
     BALGENGASZAEHLER = "BALGENGASZAEHLER"  #: Balgengaszähler
     DREHKOLBENZAEHLER = "DREHKOLBENZAEHLER"  #: Drehkolbengaszähler
     LEISTUNGSZAEHLER = "LEISTUNGSZAEHLER"  #: leistungsmessender Zähler
     MAXIMUMZAEHLER = "MAXIMUMZAEHLER"  #: Maximumzähler
     TURBINENRADGASZAEHLER = "TURBINENRADGASZAEHLER"  #: Turbinenradgaszähler
     ULTRASCHALLGASZAEHLER = "ULTRASCHALLGASZAEHLER"  #: Ultraschallgaszähler
-    WECHSELSTROMZAEHLER = (
-        "WECHSELSTROMZAEHLER"  #: Wechselstromzähler - dieser Zählertyp wird für einphasige Ferraris-Zähler verwendet
-    )
+    WECHSELSTROMZAEHLER = "WECHSELSTROMZAEHLER"
+    #: Wechselstromzähler - dieser Zählertyp wird für einphasige Ferraris-Zähler verwendet
     MODERNE_MESSEINRICHTUNG = "MODERNE_MESSEINRICHTUNG"  #: Moderne Messeinrichtung
     INTELLIGENTES_MESSSYSTEM = "INTELLIGENTES_MESSSYSTEM"  #: Intelligentes Messsystem
     ELEKTRONISCHER_ZAEHLER = "ELEKTRONISCHER_ZAEHLER"  #: Elektronischer Zähler

--- a/src/bo4e/enum/zaehlertyp.py
+++ b/src/bo4e/enum/zaehlertyp.py
@@ -8,7 +8,7 @@ class Zaehlertyp(StrEnum):
     Bei diesem Enum handelt es sich um die Abbildung von Zählertypen der Sparten Strom und Gas.
     """
 
-    DREHSTROMZAEHLER = "DREHSTROMZAEHLER"  #: Drehstromzähler
+    DREHSTROMZAEHLER = "DREHSTROMZAEHLER"  #: Drehstromzähler - dieser Zählertyp wird für Ferraris-Zähler verwendet
     BALGENGASZAEHLER = "BALGENGASZAEHLER"  #: Balgengaszähler
     DREHKOLBENZAEHLER = "DREHKOLBENZAEHLER"  #: Drehkolbengaszähler
     LEISTUNGSZAEHLER = "LEISTUNGSZAEHLER"  #: leistungsmessender Zähler


### PR DESCRIPTION
Dieser PR ergänzt den Namen Ferraris Zähler in der Dokumentation damit man es leichter zuordnen kann.