### PR TITLE
💚Fix doc creation concurrency

### DIFF
--- a/.github/workflows/docs_latest.yml
+++ b/.github/workflows/docs_latest.yml
@@ -17,6 +17,7 @@ jobs:
     # This setup is inspired by
     # https://github.com/KernelTuner/kernel_tuner/blob/master/.github/workflows/docs-on-release.yml
     runs-on: ${{ matrix.os }}
+    concurrency: build-n-publish-docs
     strategy:
       matrix:
         python-version: ["3.12"]

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -57,6 +57,7 @@ jobs:
     name: Generate JSON-Schemas
     runs-on: ubuntu-latest
     needs: [tests, check_version_tag]
+    concurrency: build-n-publish-json-schemas
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v4
@@ -104,6 +105,7 @@ jobs:
     # https://github.com/KernelTuner/kernel_tuner/blob/master/.github/workflows/docs-on-release.yml
     runs-on: ubuntu-latest
     needs: [tests, check_version_tag]
+    concurrency: build-n-publish-docs
     steps:
       - uses: actions/checkout@v4
         with:
@@ -173,6 +175,7 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     needs: [tests, json_schemas, docs]
+    concurrency: build-n-publish-distributions
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
When e.g. merging a PR, the docs /latest will be rebuild. But when you trigger a new release while the action is still running, the action to build docs for version X will fetch and checkout the gh-pages branch. One of the runs will then raise an error upon pushing.
To resolve these concurrency issues, GitHub provides a way to control it a bit: https://docs.github.com/en/actions/using-jobs/using-concurrency