### PR TITLE
fix(CI): Fixes an error in version check inside release workflow

### DIFF
--- a/docs/compatibility/versioning.py
+++ b/docs/compatibility/versioning.py
@@ -446,3 +446,4 @@ def test_version() -> None:
     assert Version.from_string("v202401.1.2-rc3", allow_candidate=True) > Version.from_string(
         "v202401.1.2-rc1", allow_candidate=True
     )
+    assert Version.from_string("v202501.2.0") > Version.from_string("v202401.10.23")


### PR DESCRIPTION
The script evaluated `202401.10.10 > 202501.1.1` before. This PR fixes the issue for now. Note, that this will be replaced by the `BO4E-CLI` in the future. The fix is more or less copied from there.