### PR TITLE
fix(versioning): 🩹Allow major bumps

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Check version tag
         run: |
           python -m docs.compatibility.versioning --gh-version ${{ github.ref_name }} \
-          --gh-token ${{ secrets.GITHUB_TOKEN }} --major-bump-disallowed
+          --gh-token ${{ secrets.GITHUB_TOKEN }}
   json_schemas:
     name: Generate JSON-Schemas
     runs-on: ubuntu-latest


### PR DESCRIPTION
Meine Idee war damals wohl, major bumps nur durch den cronjob zu erlauben. Naja, habs hiermit erstmal wieder erlaubt.